### PR TITLE
verifyrecord, denyrecord를 버튼으로 대체

### DIFF
--- a/Cogs/admin.py
+++ b/Cogs/admin.py
@@ -585,22 +585,16 @@ toktoki: app_commands.Choice[str], team: app_commands.Choice[str], infinity: app
                                             sheet.update_acell(f"{col}{i}", escape_formula(value))
                                         sort_range = f"{columns[0]}2:{columns[-1]}{self.maxranking}"
                                         sheet.sort((2, "asc"), range=sort_range)
-                                        await interaction.edit_original_response(
+                                        await interaction.followup.send(
                                             embed=discord.Embed(
-                                                title=f"✅ 기록 등록 완료 - `#{request_id}`",
-                                                description=f"""
-- **신청자** : {self.uiddata[request_id]['username'].display_name} ({self.uiddata[request_id]['username'].name})
-- **마크 닉네임** : {self.uiddata[request_id]['mcname']}
-- **트랙명** : {self.uiddata[request_id]['track']}
-- **기록** : {self.uiddata[request_id]['record']}
-- **탑승 카트** : {self.uiddata[request_id]['kart']}
-- **엔진** : {self.uiddata[request_id]['engine']}
-- **모드** : {self.uiddata[request_id]['mode']}
-- **영상** : {self.uiddata[request_id]['youtubevideo']}""",
-                                            color=EmbedColor.GREEN,
+                                                title="✅ 등록 완료",
+                                                description=f"요청 `#{request_id}`을 등록하였습니다.",
+                                                color=EmbedColor.GREEN,
                                             ),
-                                            view=discord.ui.View(),
+                                            ephemeral=True,
                                         )
+                                        await asyncio.sleep(DELAY_TO_DELETE) # 5초 뒤에 등록 요청 메세지 삭제
+                                        await interaction.delete_original_response()
                                         break
 
                                 elif sheet.acell(f"E{i}").value == mode_num and sheet.acell(f"A{i}").value == mcname:
@@ -610,22 +604,16 @@ toktoki: app_commands.Choice[str], team: app_commands.Choice[str], infinity: app
                                             sheet.update_acell(f"{col}{i}", escape_formula(value))
                                         sort_range = f"{columns[0]}2:{columns[-1]}{self.maxranking}"
                                         sheet.sort((2, "asc"), range=sort_range)
-                                        await interaction.edit_original_response(
+                                        await interaction.followup.send(
                                             embed=discord.Embed(
-                                                title=f"✅ 기록 등록 완료 - `#{request_id}`",
-                                                description=f"""
-- **신청자** : {self.uiddata[request_id]['username'].display_name} ({self.uiddata[request_id]['username'].name})
-- **마크 닉네임** : {self.uiddata[request_id]['mcname']}
-- **트랙명** : {self.uiddata[request_id]['track']}
-- **기록** : {self.uiddata[request_id]['record']}
-- **탑승 카트** : {self.uiddata[request_id]['kart']}
-- **엔진** : {self.uiddata[request_id]['engine']}
-- **모드** : {self.uiddata[request_id]['mode']}
-- **영상** : {self.uiddata[request_id]['youtubevideo']}""",
-                                            color=EmbedColor.GREEN,
+                                                title="✅ 등록 완료",
+                                                description=f"요청 `#{request_id}`을 등록하였습니다.",
+                                                color=EmbedColor.GREEN,
                                             ),
-                                            view=discord.ui.View(),
+                                            ephemeral=True,
                                         )
+                                        await asyncio.sleep(DELAY_TO_DELETE) # 5초 뒤에 등록 요청 메세지 삭제
+                                        await interaction.delete_original_response()
                                         break
                                     else:
                                         await interaction.followup.send(

--- a/Cogs/admin.py
+++ b/Cogs/admin.py
@@ -736,12 +736,12 @@ toktoki: app_commands.Choice[str], team: app_commands.Choice[str], infinity: app
             ),
             view=discord.ui.View().add_item(
                 discord.ui.Button(
-                    custom_id=make_deny_record_custom_id(uid),
+                    custom_id=CustomID.make_deny_record(uid),
                     style=discord.ButtonStyle.danger,
                     label="거절",
                 ),
                 discord.ui.Button(
-                    custom_id=make_verify_record_custom_id(uid),
+                    custom_id=CustomID.make_verify_record(uid),
                     style=discord.ButtonStyle.success,
                     label="등록",
                 ),

--- a/Cogs/admin.py
+++ b/Cogs/admin.py
@@ -733,8 +733,18 @@ toktoki: app_commands.Choice[str], team: app_commands.Choice[str], infinity: app
 - **모드** : {self.uiddata[uid]['mode']}
 - **영상** : {self.uiddata[uid]['youtubevideo']}""",
                 color=EmbedColor.YELLOW,
-            ).set_footer(
-                text="/denyrecord [ID] [사유] 를 통해 거절하거나 /verifyrecord 를 입력하여 등록해 주세요."
+            ),
+            view=discord.ui.View().add_item(
+                discord.ui.Button(
+                    custom_id=make_deny_record_custom_id(uid),
+                    style=discord.ButtonStyle.danger,
+                    label="거절",
+                ),
+                discord.ui.Button(
+                    custom_id=make_verify_record_custom_id(uid),
+                    style=discord.ButtonStyle.success,
+                    label="등록",
+                ),
             ),
             mention_author=False,
         )

--- a/Cogs/admin.py
+++ b/Cogs/admin.py
@@ -740,6 +740,7 @@ toktoki: app_commands.Choice[str], team: app_commands.Choice[str], infinity: app
                     style=discord.ButtonStyle.danger,
                     label="거절",
                 ),
+            ).add_item(
                 discord.ui.Button(
                     custom_id=CustomID.make_verify_record(uid),
                     style=discord.ButtonStyle.success,

--- a/settings.py
+++ b/settings.py
@@ -21,5 +21,5 @@ class CustomID:
     def make_deny_record(uid: int) -> str:
         return f"{CustomID.DENY_RECORD}{uid}"
 
-    def get_deny_record_custom_id(custom_id: str) -> int:
+    def get_deny_record_uid(custom_id: str) -> int:
         return int(custom_id.removeprefix(CustomID.DENY_RECORD))

--- a/settings.py
+++ b/settings.py
@@ -7,9 +7,19 @@ class EmbedColor:
     EMBED = 0x2C2D31
     LIME = 0x95FF00
     YELLOW = 0xFFFF00
-    
-def make_verify_record_custom_id(uid: int) -> str:
-    return f"#mcrider_bot/verify/{uid}"
 
-def make_deny_record_custom_id(uid: int) -> str:
-    return f"#mcrider_bot/deny/{uid}"
+class CustomID:
+    VERIFY_RECORD = "#mcrider_bot/verify/"
+    DENY_RECORD = "#mcrider_bot/deny/"
+        
+    def make_verify_record(uid: int) -> str:
+        return f"{CustomID.VERIFY_RECORD}{uid}"
+
+    def get_verify_record_uid(custom_id: str) -> int:
+        return int(custom_id.removeprefix(CustomID.VERIFY_RECORD))
+
+    def make_deny_record(uid: int) -> str:
+        return f"{CustomID.DENY_RECORD}{uid}"
+
+    def get_deny_record_custom_id(custom_id: str) -> int:
+        return int(custom_id.removeprefix(CustomID.DENY_RECORD))

--- a/settings.py
+++ b/settings.py
@@ -7,3 +7,9 @@ class EmbedColor:
     EMBED = 0x2C2D31
     LIME = 0x95FF00
     YELLOW = 0xFFFF00
+    
+def make_verify_record_custom_id(uid: int) -> str:
+    return f"#mcrider_bot/verify/{uid}"
+
+def make_deny_record_custom_id(uid: int) -> str:
+    return f"#mcrider_bot/deny/{uid}"


### PR DESCRIPTION
# 기능 요약
- 기존의 /verifyrecord, /denyrecord를 삭제하는 대신, 등록 요청 메세지 하단에 버튼을 추가하여 편의성을 높힘.
- 거절 버튼을 누르면 거절 사유를 적는 Modal 창이 뜨고, 사유를 적으면 기록 등록이 거절됨.
- 등록 버튼을 누르면 기존 처럼 등록이 됨.
- 위 두가지 버튼 모두 동작을 수행 하고나면 기존의 기록 등록 요청 메세지는 자동적으로 삭제됨.
    - 로그 채널에 로그가 남기 때문에 삭제를 하는 것이 좋을 것이라 판단하였음.
- 코드 리뷰하고, 문제 있으면 코멘트 바람.