### PR TITLE
소유자 ID 불러오는 방식 개선

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,4 +11,4 @@ REACT_GUILD_ID =  #길드 ID
 REACT_BOT_TOKEN =  #봇 토큰 (빈 상태라면 직접 봇을 만들거나 봇 제작자에게 문의해주세요)
 
 # owner_ids
-REACT_OWNER1 =  #오너 id
+REACT_OWNERS =  #오너 id (,로 구분가능)

--- a/main.py
+++ b/main.py
@@ -7,11 +7,20 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
+
+def parse_owner_id() -> list[int]:
+    owners: list[int] = []
+    id_string = os.environ.get("REACT_OWNERS")
+    for id in id_string.split(","):
+       owners.append(int(id.strip()))
+    return owners
+
+
 intents = discord.Intents.all()
 client = commands.Bot(
     command_prefix="/",
     intents=intents,
-    owner_ids=[int(os.environ.get('REACT_OWNER1')), int(os.environ.get('REACT_OWNER2')), int(os.environ.get('REACT_OWNER3'))],
+    owner_ids=parse_owner_id(),
 )
 
 


### PR DESCRIPTION
# 고지
- **이 수정사항이 병합되고 나면 `.env` 파일의 수정이 필요함.**
- 아래와 같은 방식으로 변경 (콤마 이후 띄어쓰기는 선택.)
```diff
# .env
- REACT_OWNER1=123
- REACT_OWNER2=456
- REACT_OWNER3=789
+ REACT_OWNERS=123,456,789
```

# 변경점
- 기존 무조건 소유자를 세 명 지정해야했던 것에서, 최소 한 명, 최대는 무제한으로 할 수 있게 변경